### PR TITLE
Add option to let user set submit event listener using custom callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ var card = new CardHelper({
    */
   onCardTypeChange : false,
 
+  /*
+   *  If given a callback function, the function will be invoked instead of
+   *  setting the submit event. Default submit event listener is placed on
+   *  `body`. It may be desirable to place the submit event on another
+   *  element, such as the form itself, to prevent propagation of other
+   *  form submit events. It will be passed the options and the submit
+   *  event handler callback.
+   */
+  setListenerFormSubmit : false
 
   /* 
    *  Whether or not to remove an existing pattern attribute

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ var card = new CardHelper({
    */
   setListenerFormSubmit : false
 
+  /*
+   *  If given a callback function, the function will be invoked after all
+   *  checks are run. It will be passed true or false indicating either that
+   *  all checks have passed or that at least one check has failed.
+   */
+  afterSubmit : false
+
+
+
   /* 
    *  Whether or not to remove an existing pattern attribute
    *  from inputCardNumber and inputCVC to prevent conflicts.

--- a/cc-helper.js
+++ b/cc-helper.js
@@ -26,7 +26,8 @@
         incompleteCardNum : true,
         incompleteCVC     : true,
         failedLuhn        : true,
-      }
+      },
+      setListenerFormSubmit : false
     };
     var opts = $.extend( true, {}, defaultOptions, userOptions );
 
@@ -78,7 +79,12 @@
 
   function setListenerFormSubmit (opts) {
     // check opts for prevent submit options
-    $('body').on('submit', opts.selectors.form, evtHandlerFormSubmit);
+
+    if (opts.setListenerFormSubmit) {
+      opts.setListenerFormSubmit(opts, evtHandlerFormSubmit);
+    } else {
+      $('body').on('submit', opts.selectors.form, evtHandlerFormSubmit);
+    }
 
     function evtHandlerFormSubmit (e) {
       var $cardNumInputEl = opts.modifyOnSubmit ? $('[name="'+clonedFieldName+'"]') : $(opts.selectors.inputCardNumber);

--- a/cc-helper.js
+++ b/cc-helper.js
@@ -27,7 +27,8 @@
         incompleteCVC     : true,
         failedLuhn        : true,
       },
-      setListenerFormSubmit : false
+      setListenerFormSubmit : false,
+      afterSubmit : false
     };
     var opts = $.extend( true, {}, defaultOptions, userOptions );
 
@@ -96,17 +97,21 @@
       var o = opts.preventSubmitIf;
       // If any preventSubmit options are enabled, and the corresponding check
       // fails, cancel submission, and display the appropriate error message
+      var ret = true;
       if ( o.incompleteCardNum && !isCompleteCardNum(cardNum)     ) {
         displayErr( $cardNumInputEl, $('#'+errMsgNumber), opts );
-        return cancelEvent(e);
-      }
-      if ( o.incompleteCVC     && !isCompleteCVC(cardNum,cardCVC) ) {
+        ret = cancelEvent(e);
+      } else if ( o.incompleteCVC     && !isCompleteCVC(cardNum,cardCVC) ) {
         displayErr( $cardCVCInputEl, $('#'+errMsgCVC), opts );
-        return cancelEvent(e);
+        ret = cancelEvent(e);
+      } else if ( o.failedLuhn        && !isValidLuhn(cardNum)           ) {
+        ret = cancelEvent(e);
       }
-      if ( o.failedLuhn        && !isValidLuhn(cardNum)           ) return cancelEvent(e);
 
-
+      // call afterSubmit callback if present
+      if (opts.afterSubmit) {
+        opts.afterSubmit(ret);
+      }
 
       // If a modifyOnSubmit callback is specified, run it on the value of the
       // cloned field, and insert the result into the hidden field for submission


### PR DESCRIPTION
If the form on the page uses JS instead of a standard form submission, it is necessary for any cc-helper JS to run before default form submission code.

This is necessary because otherwise `modifyOnSubmit` (i.e. removing spaces from cc number) will not run in time and an invalid card number will be submitted.

To make cc-helper submit event handler run first:

1. Place JS code earlier in the page
1. Ensure submit event is on same element

Default code places the submit event on `body`, and the plugin in my use case places the event on the form itself. In order to stop propagation of the default submission event on invalid card, I need to place the cc-helper event on the form itself. In my invocation, I have this new option set like so:

```javascript
{
  setListenerFormSubmit : function(opts, handler) {
    jQuery(opts.selectors.form).on('submit', handler);
  },
}
```